### PR TITLE
Filter mailboxes by collection times

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) [2015] [Danilo Bretschneider]
+Copyright (c) 2020 Tobias Preuss
+Copyright (c) 2015 Danilo Bretschneider
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,37 +1,35 @@
-# briefkastenkarte.de
+# briefkastenkarte
+
+Visualizing mailbox locations based on data retrieved from [OpenStreetMap][openstreetmap-org].
+
+## Features
+
+- Show mailboxes with their attributes
+- Show post offices with their attributes
+- Allow to filter for mailboxes:
+  - which are emptied Sundays
+  - without collection times
+  - which have not been edited since a year or more
+  - with an address
+- Show the mailboxes service area
+
+
+## History
+
+- The project was started by [Danilo Bretschneider][dbretschneider-github]
+  in January 2015 and published as *briefkastenkarte.de*. Development stopped
+  in March 2015.
+- In April 2020 [Tobias Preuss][johnjohndoe-github] relaunched the project
+  as "briefkastenkarte" based on the original code base. The aim is to have
+  a running website deployed and usable both from mobile phones and desktop
+  browsers.
+
 
 ## License
-- *briefkastenkarte.de* is licensed under the [MIT License] [1] and includes other
-libraries or parts of libraries which have their own license file or license
-annotation in the source code:
 
- - Leaflet - [MIT License] [2]
- - OverPass PlugIn - [MIT License] [3]
- - Awesome Markers - [MIT License] [4]
- - Font Awesome - [SIL OFL 1.1] [5]
- - jQuery - [MIT License] [6]
- - Control Loading - [MIT License] [7]
- - Bootstrap - [MIT License] [8]
- - L.GeoSearch - [MIT License] [9]
- - Leaflet.Locate - [MIT License] [10]
- - Leaflet.plugins - [MIT License] [11]
- - jQuery UI - [MIT License] [12]
- - jQuery Cookie Plugin - [MIT License] [13]
- - Sparkling Theme [GNU GPL v3.0] [14]
- - Leaflet.groupedlayercontrol - [MIT License] [15]
+- *briefkastenkarte* is licensed under the [MIT License](LICENSE).
 
-  [1]: http://opensource.org/licenses/mit-license.html
-  [2]: https://github.com/Leaflet/Leaflet/blob/master/LICENSE
-  [3]: https://github.com/kartenkarsten/leaflet-layer-overpass/blob/master/LICENSE
-  [4]: https://github.com/lvoogdt/Leaflet.awesome-markers/blob/2.0/develop/LICENSE
-  [5]: http://fortawesome.github.io/Font-Awesome/license
-  [6]: https://jquery.org/license/
-  [7]: https://github.com/ebrelsford/Leaflet.loading/blob/master/LICENSE
-  [8]: http://getbootstrap.com/getting-started/#license-faqs
-  [9]: https://github.com/smeijer/L.GeoSearch/blob/master/LICENSE
-  [10]: https://github.com/domoritz/leaflet-locatecontrol/blob/gh-pages/LICENSE
-  [11]: https://github.com/shramov/leaflet-plugins/blob/master/LICENSE
-  [12]: https://jquery.org/license/
-  [13]: https://github.com/carhartl/jquery-cookie/blob/master/MIT-LICENSE.txt
-  [14]: https://github.com/puikinsh/Sparkling/blob/master/readme.txt
-  [15]: https://github.com/ismyrnow/Leaflet.groupedlayercontrol/blob/gh-pages/MIT-LICENSE.txt
+
+[openstreetmap-org]: https://www.openstreetmap.org
+[dbretschneider-github]: https://github.com/dbretschneider
+[johnjohndoe-github]: https://github.com/johnjohndoe

--- a/briefkastenkarte.js
+++ b/briefkastenkarte.js
@@ -623,6 +623,11 @@ $(document).ready(function() {
 		}
 	});
 
+	$("#collection-times-filter select").mousedown(function(event) {
+		// Drag the select drop down instead of the map
+		stopEventPropagation(event);
+	});
+
 	function updateCollectionTimesFilterFormVisibility(visible) {
 		var formElement = $(".collection-times-form");
 		if (visible) {
@@ -630,6 +635,15 @@ $(document).ready(function() {
 		}
 		else {
 			formElement.hide();
+		}
+	}
+
+	function stopEventPropagation(event) {
+		if (event.stopPropagation) {
+			event.stopPropagation();
+		}
+		else if (event.cancelBubble !== null) {
+			event.cancelBubble = true;
 		}
 	}
 

--- a/briefkastenkarte.js
+++ b/briefkastenkarte.js
@@ -608,6 +608,30 @@ $(document).ready(function() {
 	L.control.groupedLayers(baseMaps, groupedOverlays).addTo(map);
 
 
+	// Show and hide collection time filter for mailboxes
+	// The filter is only displayed when the mailbox layer is active
+	map.on({
+		overlayadd: function(event) {
+			if (event.name === "Briefkästen") {
+				updateCollectionTimesFilterFormVisibility(true);
+			}
+		},
+		overlayremove: function(event) {
+			if (event.name === "Briefkästen") {
+				updateCollectionTimesFilterFormVisibility(false);
+			}
+		}
+	});
+
+	function updateCollectionTimesFilterFormVisibility(visible) {
+		var formElement = $(".collection-times-form");
+		if (visible) {
+			formElement.show();
+		}
+		else {
+			formElement.hide();
+		}
+	}
 
 	function parseCheckTimes(tags) {
 		var currentTime = new Date(); //today

--- a/briefkastenkarte.js
+++ b/briefkastenkarte.js
@@ -79,7 +79,7 @@ $(document).ready(function() {
 		};
 	};
 
-	var map = new L.map('map').setView([50.7344700,7.0987190], 15);
+	var map = new L.map('map').setView([52.52,13.405], 15);
 
 	var OpenStreetMap_Mapnik = L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> Mitwirkende',

--- a/briefkastenkarte.js
+++ b/briefkastenkarte.js
@@ -88,7 +88,7 @@ $(document).ready(function() {
 
 	var post_box = new L.OverPassLayer({
 		minzoom: 12,
-		query: "(node(BBOX)[amenity=post_box]);out;",
+		query: "node(BBOX)['amenity'='post_box'];out;",
 
 		callback: function(data) {
 			for(var i=0;i<data.elements.length;i++) {
@@ -153,7 +153,7 @@ $(document).ready(function() {
 
 	var post_box_addr_street = new L.OverPassLayer({
 		minzoom: 12,
-		query: "(node(BBOX)[amenity=post_box]['addr:street'~'.']);out;",
+		query: "node(BBOX)['amenity'='post_box']['addr:street'~'.'];out;",
 
 		callback: function(data) {
 			for(var i=0;i<data.elements.length;i++) {
@@ -230,7 +230,7 @@ $(document).ready(function() {
 
 	var post_box_no_collection_times = new L.OverPassLayer({
 		minzoom: 12,
-		query: "(node(BBOX)[amenity=post_box][collection_times!~'.']);out;",
+		query: "node(BBOX)['amenity'='post_box'][collection_times!~'.'];out;",
 
 		callback: function(data) {
 			for(var i=0;i<data.elements.length;i++) {
@@ -292,7 +292,7 @@ $(document).ready(function() {
 
 	var post_box_sunday = new L.OverPassLayer({
 		minzoom: 12,
-		query: "(node(BBOX)[amenity=post_box][collection_times~'Su']);out;",
+		query: "node(BBOX)['amenity'='post_box'][collection_times~'Su'];out;",
 
 		callback: function(data) {
 			for(var i=0;i<data.elements.length;i++) {
@@ -353,6 +353,7 @@ $(document).ready(function() {
 	});
 	var currentTime = new Date(); //today
 	var day = currentTime.getDate();
+	var twoDigitsDay = (day < 10 ? '0' : '') + day;
 
 	var monthArray = new Array(12);
 	monthArray[0] = "01";
@@ -373,7 +374,7 @@ $(document).ready(function() {
 
 	var post_box_check_collection_times = new L.OverPassLayer({
 		minzoom: 12,
-		query: "(   ( node(BBOX)[amenity=post_box];  - node(BBOX)[amenity=post_box](newer:'" + year + "-" + month + "-" + day + "T00:00:00Z'); ););out center meta;",
+		query: "(node(BBOX)['amenity'='post_box']; - node(BBOX)['amenity'='post_box'](newer:'" + year + "-" + month + "-" + twoDigitsDay + "T00:00:00Z'););out center meta;",
 
 		callback: function(data) {
 			for(var i=0;i<data.elements.length;i++) {
@@ -435,7 +436,7 @@ $(document).ready(function() {
 
 	var post_office = new L.OverPassLayer({
 		minzoom: 12,
-		query: "(node(BBOX)[amenity=post_office ]);out;",
+		query: "node(BBOX)['amenity'='post_office'];out;",
 
 		callback: function(data) {
 			for(var i=0;i<data.elements.length;i++) {
@@ -487,7 +488,7 @@ $(document).ready(function() {
 
 	var post_box_service_area = new L.OverPassLayer({
 		minzoom: 12,
-		query: "(node(BBOX)[amenity=post_box ]);out;",
+		query: "node(BBOX)['amenity'='post_box'];out;",
 
 		callback: function(data) {
 			for(var i=0;i<data.elements.length;i++) {

--- a/briefkastenkarte.js
+++ b/briefkastenkarte.js
@@ -663,6 +663,11 @@ $(document).ready(function() {
 		filterPoints();
 	});
 
+	$("#collection-times-filter-reset").submit(function(event) {
+		event.preventDefault();
+		showAllPoints();
+	});
+
 	function updateCollectionTimesFilterFormVisibility(visible) {
 		var formElement = $(".collection-times-form");
 		if (visible) {
@@ -690,6 +695,19 @@ $(document).ready(function() {
 		}
 		else if (event.cancelBubble !== null) {
 			event.cancelBubble = true;
+		}
+	}
+
+	function showAllPoints() {
+		var mapLayers = map._layers;
+		for (var key in mapLayers) {
+			if (mapLayers.hasOwnProperty(key)) {
+				// This object might be a marker
+				var object = mapLayers[key];
+				if (object.hasOwnProperty("mailBox")) {
+					updateMarkerVisibility(object, true);
+				}
+			}
 		}
 	}
 

--- a/css/briefkastenkarte.css
+++ b/css/briefkastenkarte.css
@@ -9,7 +9,6 @@ body {
   line-height: 20px;
   font-weight: 400;
   color: #3b3b3b;
-  background: #2b2b2b;
 }
 
 .wrapper {
@@ -95,8 +94,8 @@ Begin
 */
 #map {
   position: absolute;
-  top: 76px;
-  bottom: 70px;
+  top: 0px;
+  bottom: 0px;
   left: 0;
   right: 0;
   z-index: -1;

--- a/css/briefkastenkarte.css
+++ b/css/briefkastenkarte.css
@@ -110,3 +110,30 @@ Begin
 CSS map
 End
 */
+
+
+.collection-times-form h1 {
+  margin: 0 0 0.25em 0;
+  font-family: "Open Sans",sans-serif;
+  font-size: 1.3em;
+  color: #000;
+}
+
+.collection-times-form {
+  background: #fff;
+  width: 50em;
+  margin-left: 50px !important;
+  padding: 0.25em 1em;
+  z-index: 8;
+}
+
+#collection-times-filter {
+  display: inline;
+  float: left;
+  margin-right: 1em;
+}
+
+#collection-times-filter-error {
+  clear: both;
+  color: #ce3c29; /* marker red */
+}

--- a/css/briefkastenkarte.css
+++ b/css/briefkastenkarte.css
@@ -63,7 +63,7 @@ body {
   padding: 5px 15px;
   display: table-cell;
   width: 130px;
-  
+
 }
 @media screen and (max-width: 580px) {
   .cell {
@@ -75,7 +75,7 @@ body {
 .cell_noinfo {
   padding: 5px 15px;
   display: table-cell;
-  
+
 }
 @media screen and (max-width: 580px) {
   .cell_noinfo {

--- a/external/leaflet-layer-overpass/OverPassLayer.js
+++ b/external/leaflet-layer-overpass/OverPassLayer.js
@@ -105,7 +105,7 @@ L.OverPassLayer = L.FeatureGroup.extend({
   options: {
     minzoom: 15,
     //endpoint: "http://overpass.osm.rambler.ru/cgi/",
-    endpoint: "http://overpass-api.de/api/",
+    endpoint: "https://overpass-api.de/api/",
     query: "(node(BBOX)[organic];node(BBOX)[second_hand];);out qt;",
     callback: function(data) {
         if (this.instance._map == null) {

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <link rel="icon" href="images/favicon.png" type="image/png"/>
     <link rel="shortcut icon" href="images/favicon.png" type="image/png"/>
 
-    <title>Briefkastenkarte gesucht? » Briefkastenkarte.de</title>
+    <title>Briefkastenkarte</title>
 
     <!-- Leaflet - downloaded from http://leafletjs.com/download.html -->
     <link rel="stylesheet" href="external/leaflet-0.7.3/leaflet.css"/>
@@ -80,84 +80,12 @@
 
 </head>
 
-<body class="page page-id-1821 page-template page-template-page-fullwidth page-template-page-fullwidth-php group-blog">
+<body>
 
-<div id="page" class="hfeed site">
-
-    <header id="masthead" class="site-header" role="banner">
-        <nav class="navbar navbar-default" role="navigation">
-            <div class="container">
-                <div class="row">
-                    <div class="site-navigation-inner col-sm-12">
-                        <div class="navbar-header">
-                            <button type="button" class="btn navbar-toggle" data-toggle="collapse"
-                                    data-target=".navbar-ex1-collapse">
-                                <span class="sr-only">Navigation ein-/ausblenden</span>
-                                <span class="icon-bar"></span>
-                                <span class="icon-bar"></span>
-                                <span class="icon-bar"></span>
-                            </button>
-
-
-                            <div id="logo">
-                                <span class="site-name"><a class="navbar-brand" href="http://www.briefkastenkarte.de/"
-                                                           title="Briefkastenkarte.de"
-                                                           rel="home">Briefkastenkarte.de</a></span>
-                            </div>
-                            <!-- end of #logo -->
-
-
-                        </div>
-                        <div class="collapse navbar-collapse navbar-ex1-collapse">
-                            <ul id="menu-top" class="nav navbar-nav">
-                                <li id="menu-item-1782"
-                                    class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1782"><a
-                                        title="Blog" target="_blank" href="http://blog.briefkastenkarte.de/">Blog</a>
-                                </li>
-                                <li id="menu-item-1782"
-                                    class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1782"><a
-                                        title="Kontakt" target="_blank"
-                                        href="http://blog.briefkastenkarte.de/kontakt/">Kontakt</a>
-                                </li>
-                                <li id="menu-item-1782"
-                                    class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1782"><a
-                                        title="Datenschutz" target="_blank"
-                                        href="http://blog.briefkastenkarte.de/datenschutz/">Datenschutz</a>
-                                </li>
-                                <li id="menu-item-1782"
-                                    class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1782"><a
-                                        title="Impressum" target="_blank"
-                                        href="http://blog.briefkastenkarte.de/impressum/">Impressum</a></li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </nav>
-        <!-- .site-navigation -->
-    </header>
-    <!-- #masthead -->
-
+<div id="page">
     <div id="content" class="site-content">
-        <div id="map"></div>
+        <div id="map" />
     </div>
-
-</div>
-<!-- #page -->
-<div id="footer-area">
-    <div class="container footer-inner">
-        <div class="row"></div>
-    </div>
-    <footer id="colophon" class="site-footer" role="contentinfo">
-        <div class="site-info container">
-            <div class="row">
-                <div class="social-icons"></div>
-                <nav role="navigation" class="col-md-6"></nav>
-                <div class="copyright col-md-8">Diese Website benutzt Piwik, eine Open-Source-Software zur statistischen Auswertung der Besucherzugriffe. Informiere dich <a href="http://blog.briefkastenkarte.de/datenschutz/" target="_blank">hier</a> über Cookies oder deaktivere das Tracking. <br> » <a href="http://www.briefkastenkarte.de">Briefkastenkarte.de</a> « Theme von <a href="http://www.colorlib.com/" target="_blank">Colorlib</a></div>
-            </div>
-        </div>
-        <div class="scroll-to-top"><i class="fa fa-angle-up"></i></div>
-    </footer>
 </div>
 
 <script type="text/javascript" src="external/bootstrap/bootstrap.js"></script>

--- a/index.html
+++ b/index.html
@@ -163,23 +163,5 @@
 <script type="text/javascript" src="external/bootstrap/bootstrap.js"></script>
 <script src="briefkastenkarte.js"></script>
 
-<!-- Piwik -->
-<script type="text/javascript">
-  var _paq = _paq || [];
-  _paq.push(["setCookieDomain", "*.briefkastenkarte.de"]);
-  _paq.push(["setDomains", ["*.briefkastenkarte.de"]]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//piwik.bretsch.net/";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', 2]);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//piwik.bretsch.net/piwik.php?idsite=2" style="border:0;" alt=""/></p></noscript>
-<!-- End Piwik Code -->
-
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -85,10 +85,93 @@
 <div id="page">
     <div id="content" class="site-content">
         <div id="map" />
+            <div class="leaflet-control-container">
+                <div class="leaflet-top leaflet-left">
+                    <div class="leaflet-control-zoom leaflet-bar leaflet-control collection-times-form">
+
+                        <div>
+                            <h1>Briefk&auml;sten nach Abholzeiten filtern</h1>
+                            <form id="collection-times-filter" action="#">
+                                <label for="week-day">Am</label>
+                                <select name="week-day" id="week-day">
+                                    <option value="WeekDays.monday">Montag</option>
+                                    <option value="WeekDays.tuesday">Dienstag</option>
+                                    <option value="WeekDays.wednesday">Mittwoch</option>
+                                    <option value="WeekDays.thursday">Donnerstag</option>
+                                    <option value="WeekDays.friday">Freitag</option>
+                                    <option value="WeekDays.saturday">Samstag</option>
+                                    <option value="WeekDays.sunday">Sonntag</option>
+                                </select>
+                                <label for="start-time">zwischen</label>
+                                <select name="start-time" id="start-time">
+                                    <option value="01:00">01:00</option>
+                                    <option value="02:00">02:00</option>
+                                    <option value="03:00">03:00</option>
+                                    <option value="04:00">04:00</option>
+                                    <option value="05:00">05:00</option>
+                                    <option value="06:00">06:00</option>
+                                    <option value="07:00">07:00</option>
+                                    <option value="08:00" selected>08:00</option>
+                                    <option value="09:00">09:00</option>
+                                    <option value="10:00">10:00</option>
+                                    <option value="11:00">11:00</option>
+                                    <option value="12:00">12:00</option>
+                                    <option value="13:00">13:00</option>
+                                    <option value="14:00">14:00</option>
+                                    <option value="15:00">15:00</option>
+                                    <option value="16:00">16:00</option>
+                                    <option value="17:00">17:00</option>
+                                    <option value="18:00">18:00</option>
+                                    <option value="19:00">19:00</option>
+                                    <option value="20:00">20:00</option>
+                                    <option value="21:00">21:00</option>
+                                    <option value="22:00">22:00</option>
+                                    <option value="23:00">23:00</option>
+                                    <option value="00:00">00:00</option>
+                                </select>
+                                <label for="end-time">und</label>
+                                <select name="end-time" id="end-time">
+                                    <option value="01:00">01:00</option>
+                                    <option value="02:00">02:00</option>
+                                    <option value="03:00">03:00</option>
+                                    <option value="04:00">04:00</option>
+                                    <option value="05:00">05:00</option>
+                                    <option value="06:00">06:00</option>
+                                    <option value="07:00">07:00</option>
+                                    <option value="08:00">08:00</option>
+                                    <option value="09:00">09:00</option>
+                                    <option value="10:00">10:00</option>
+                                    <option value="11:00">11:00</option>
+                                    <option value="12:00" selected>12:00</option>
+                                    <option value="13:00">13:00</option>
+                                    <option value="14:00">14:00</option>
+                                    <option value="15:00">15:00</option>
+                                    <option value="16:00">16:00</option>
+                                    <option value="17:00">17:00</option>
+                                    <option value="18:00">18:00</option>
+                                    <option value="19:00">19:00</option>
+                                    <option value="20:00">20:00</option>
+                                    <option value="21:00">21:00</option>
+                                    <option value="22:00">22:00</option>
+                                    <option value="23:00">23:00</option>
+                                    <option value="00:00">00:00</option>
+                                </select>
+                                <input type="submit" value="Absenden" />
+                            </form>
+                            <form id="collection-times-filter-reset" action="#">
+                                <input type="submit" value="Alle Briefkästen anzeigen" />
+                            </form>
+                            <p id="collection-times-filter-error" />
+                        </div>
+
+                    </div>
+                </div>
+            </div>
     </div>
 </div>
 
 <script type="text/javascript" src="external/bootstrap/bootstrap.js"></script>
+<script type="text/javascript" src="js/mailbox.js"></script>
 <script src="briefkastenkarte.js"></script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -6,13 +6,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="OSM-Themenkarte zur Darstellung von Briefkästen und deren Leerungszeiten">
-    <meta name="author" content="Danilo Bretschneider, levante">
-    <meta name="publisher" content="Danilo Bretschneider, levante">
+    <meta name="author" content="Danilo Bretschneider and others">
+    <meta name="publisher" content="Danilo Bretschneider and others">
     <meta name="copyright" content="MIT License"/>
-    <meta name="title" content="Briefkastenkarte gesucht? » Briefkastenkarte.de"/>
+    <meta name="title" content="Briefkastenkarte"/>
     <meta name="keywords"
           content="openstreetmap, briefkastenkarte, danilo bretschneider, levante, leaflet, osm, briefkasten, briefkasten gesucht, postkarte, leerungszeiten, deutsche post, briefkasten finden, briefkasten in der nähe finden"/>
-    <meta name="date" content="2015-02-14"/>
     <meta name="page-topic" content="Briefkastenkarte"/>
     <meta name="robots" content="index,nofollow"/>
 

--- a/js/mailbox.js
+++ b/js/mailbox.js
@@ -7,3 +7,228 @@ var WeekDays = Object.freeze({
     "saturday" : 6,
     "sunday" : 7
 });
+
+function MailBox() {
+    this.operator = "";
+    this.brand = "";
+    this.ref = "";
+    // Holds an of WeekDayCollectionTimes objects OR []
+    this.weekCollectionTimes = [];
+}
+
+function CollectionTime(hourMinutes) {
+    this.hourMinutes = hourMinutes;
+    this.date = undefined;
+
+    this.setDate = function(datePart) {
+        var str = datePart + " " + this.hourMinutes + ":00";
+        this.date = new Date(str);
+    };
+
+    // Use this artifical date to create a comparable date object
+    // Only hours and minutes are actually used!
+    this.setDate("2000/01/01");
+}
+
+function WeekDayCollectionTimes(weekDay, collectionTimeArray) {
+    this.weekDay = weekDay;
+    // Holds an array of CollectionTime objects
+    this.collectionTimeArray = collectionTimeArray;
+}
+
+// startDate and endDate must be of type CollectionTime
+function DateRange(startCollectionTime, endCollectionTime) {
+    this.startCollectionTime = startCollectionTime;
+    this.endCollectionTime = endCollectionTime;
+
+    this.isValid = function() {
+        return (startCollectionTime.date < endCollectionTime.date);
+    }
+
+    // date must be of type Date
+    this.contains = function(date) {
+        return (this.startCollectionTime.date <= date && date <= this.endCollectionTime.date);
+    },
+
+    this.toString = function() {
+        return "[" + this.startCollectionTime.hourMinutes + "; " + this.endCollectionTime.hourMinutes + "]";
+    }
+}
+
+function WeekDayDateRange(weekDay, dateRange) {
+    this.weekDay = weekDay;
+    this.dateRange = dateRange;
+
+    // Expects an array of WeekDayCollectionTimes objects
+    this.contains = function(weekCollectionTimes) {
+
+        if (weekCollectionTimes === undefined || weekCollectionTimes.length == 0) {
+            throw "The weekCollectionTimes passed is undefined or an empty array."
+        }
+
+        // This is an array of WeekDayCollectionTimes
+        for (var arrayIndex = 0; arrayIndex < weekCollectionTimes.length; ++arrayIndex) {
+            // This is a WeekDayCollectionTimes object
+            var currentWeekDaysCollectionTimes = weekCollectionTimes[arrayIndex];
+
+            if (currentWeekDaysCollectionTimes.weekDay !== this.weekDay) {
+                continue;
+            }
+
+            var collectionTimeArray = currentWeekDaysCollectionTimes.collectionTimeArray;
+            for (var collectionTimeIndex = 0; collectionTimeIndex < collectionTimeArray.length; ++collectionTimeIndex) {
+                // This is a CollectionTime object
+                var collectionTime = collectionTimeArray[collectionTimeIndex];
+                if (this.dateRange.contains(collectionTime.date)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}
+
+// Returns an array of CollectionTime objects OR undefinded
+// Parse collection times from "hh:mm, hh:mm, ..."
+function parseCollectionTimes(hourMinutesString) {
+    if (hourMinutesString === undefined) {
+        throw "The hourMinutesString passed is undefined."
+    }
+
+    // Remove trailing spaces
+    hourMinutesString = hourMinutesString.trim();
+    // Remove all white space
+    hourMinutesString = hourMinutesString.replace(/\s+/g, "");
+
+    if (hourMinutesString.length == 0) {
+        console.log("hourMinutesString is empty");
+        return undefined;
+    }
+
+    // Convert into array as in ["hh:mm", "hh:mm", ...]
+    var hourMinutesArray = hourMinutesString.split(",");
+
+    var collectionTimesArray = [];
+    for (var hourMinuteIndex = 0; hourMinuteIndex < hourMinutesArray.length; ++hourMinuteIndex) {
+        var hourMinute = hourMinutesArray[hourMinuteIndex];
+        var collectionTime = new CollectionTime(hourMinute);
+        collectionTimesArray.push(collectionTime);
+    }
+    if (collectionTimesArray.length == 0) {
+        console.log("collectionTimesArray is empty");
+        return undefined;
+    }
+    return collectionTimesArray;
+}
+
+// Returns an array of week day strings in lowercase OR undefined
+// Example: Expands "Mo-Fr" to ["mo", "tu", "we", "th", "fr"]
+function expandWeekDays(weekDaysString) {
+    if (weekDaysString === undefined) {
+        throw "The weekDaysString passed is undefined."
+    }
+
+    weekDaysString = weekDaysString.trim();
+    weekDaysString = weekDaysString.replace(/\s+/g, "");
+
+    if (weekDaysString.length == 0) {
+        console.log("weekDaysString is empty");
+        return undefined;
+    }
+
+    weekDaysString = weekDaysString.toLowerCase();
+    weekDaysString = weekDaysString.replace("so", "su");
+    if (weekDaysString.indexOf("-") > -1) {
+        if (weekDaysString.indexOf("mo-fr") > -1) {
+            return ["mo", "tu", "we", "th", "fr"];
+        }
+        else {
+            // You might wanna add other cases similar
+            // to the one above if this exception is thrown.
+            throw "Unknown week day " + weekDaysString;
+        }
+    }
+    // In this case weekDaysString should contain a single week day
+    return [weekDaysString];
+}
+
+// Retuns an array of WeekDayCollectionTimes objects OR an empty array
+function parseWeekCollectionTimes(collectionTimesChunks) {
+    var weekCollectionTimes = [];
+    for (var chunkIndex = 0; chunkIndex < collectionTimesChunks.length; ++chunkIndex) {
+        // A chunk can be "Mo-Fr 14:00" or "Su 17:30"
+        var collectionTimesChunk = collectionTimesChunks[chunkIndex];
+        // Trim white space
+        collectionTimesChunk = collectionTimesChunk.trim();
+
+        // No collection time information available.
+        if (collectionTimesChunk.length == 0) {
+            continue;
+        }
+
+        // Split into weekday(s) and times: "Mo-Fr 14:00, 16:30" -> ["Mo-Fr", "14:00, 16:30"]
+        var separatedWeekDaysAndCollectionTimes = collectionTimesChunk.split(" ");
+        // Parse week days and collection times
+
+        // This is an array of WeekDayCollectionTimes objects
+        var weekDaysAndCollectionTimes = parseWeekDaysAndCollectionTimes(separatedWeekDaysAndCollectionTimes);
+        if (weekDaysAndCollectionTimes !== undefined) {
+            weekCollectionTimes = weekCollectionTimes.concat(weekDaysAndCollectionTimes);
+        }
+    }
+    return weekCollectionTimes;
+}
+
+// Returns an array of WeekDayCollectionTimes objects OR undefined
+function parseWeekDaysAndCollectionTimes(weekDaysCollectionTimesArray) {
+    var collectionTimesArray = parseCollectionTimes(weekDaysCollectionTimesArray[1]);
+    if (collectionTimesArray === undefined) {
+        console.log("collectionTimesArray is undefined");
+        return undefined;
+    }
+
+    var weekDaysArray = expandWeekDays(weekDaysCollectionTimesArray[0]);
+    if (weekDaysArray === undefined) {
+        console.log("weekDaysArray is undefined");
+        return undefined;
+    }
+
+    // Store week day with collection times
+    var weekDayCollectionTimes = [];
+
+
+    if (weekDaysArray.indexOf("mo") > -1) {
+        var weekDayCollectionTime = new WeekDayCollectionTimes(WeekDays.monday, collectionTimesArray);
+        weekDayCollectionTimes.push(weekDayCollectionTime);
+    }
+    if (weekDaysArray.indexOf("tu") > -1) {
+        var weekDayCollectionTime = new WeekDayCollectionTimes(WeekDays.tuesday, collectionTimesArray);
+        weekDayCollectionTimes.push(weekDayCollectionTime);
+    }
+    if (weekDaysArray.indexOf("we") > -1) {
+        var weekDayCollectionTime = new WeekDayCollectionTimes(WeekDays.wednesday, collectionTimesArray);
+        weekDayCollectionTimes.push(weekDayCollectionTime);
+    }
+    if (weekDaysArray.indexOf("th") > -1) {
+        var weekDayCollectionTime = new WeekDayCollectionTimes(WeekDays.thursday, collectionTimesArray);
+        weekDayCollectionTimes.push(weekDayCollectionTime);
+    }
+    if (weekDaysArray.indexOf("fr") > -1) {
+        var weekDayCollectionTime = new WeekDayCollectionTimes(WeekDays.friday, collectionTimesArray);
+        weekDayCollectionTimes.push(weekDayCollectionTime);
+    }
+    if (weekDaysArray.indexOf("sa") > -1) {
+        var weekDayCollectionTime = new WeekDayCollectionTimes(WeekDays.saturday, collectionTimesArray);
+        weekDayCollectionTimes.push(weekDayCollectionTime);
+    }
+    if (weekDaysArray.indexOf("su") > -1) {
+        var weekDayCollectionTime = new WeekDayCollectionTimes(WeekDays.sunday, collectionTimesArray);
+        weekDayCollectionTimes.push(weekDayCollectionTime);
+    }
+
+    if (weekDayCollectionTimes.length == 0) {
+        console.log("weekDayCollectionTimes is empty");
+        return undefined;
+    }
+    return weekDayCollectionTimes;
+}

--- a/js/mailbox.js
+++ b/js/mailbox.js
@@ -1,0 +1,9 @@
+var WeekDays = Object.freeze({
+    "monday" : 1,
+    "tuesday" : 2,
+    "wednesday" : 3,
+    "thursday" : 4,
+    "friday" : 5,
+    "saturday" : 6,
+    "sunday" : 7
+});


### PR DESCRIPTION
I put some work into this **collection times filter**. This resolves issue #2.
# Features
- It allows to **hide mailboxes** which do **not** match with time range specified by the user.
- I also added a button to **reset the filter** - to show all mailboxes again.
- The whole filter control is **only visible when the associated layer "Briefkästen" is enabled**.
- **Error messages** are displayed under the controls when the time range is invalid.

![Collection times filter](https://cloud.githubusercontent.com/assets/144518/7004339/3012af86-dc6a-11e4-8864-55747ab529dd.png)
# Review please

Please feel free to test it and leave your comments here. Big thanks belong to @k-nut who helped me to get rid of some of the painful Javascript errors I included. I structured the feature branch into atomic commits which hopefully make it easier to follow my thoughts. There are also a couple of comments in the code since the nested Javascript objects become confusing quickly.
# Merge strategy

It would be nice if you use the following commands to create an **explicit, empty** merge commit:

``` bash
$ git checkout feature/filter-by-collection-times-2
$ git checkout develop
$ git merge --no-ff feature/filter-by-collection-times-2
```

This will make it easier to **visually recognize** the feature and its commits:

```
*    3b19044 : Merge branch 'feature/filter-by-collection-times-2' into develop
|\  
| *  b13de83 : Allow resetting the visibility of all mailboxes.
| *  5218311 : Filter mailboxes by collection time.
| *  1d570f9 : Fix dragging the map instead of the select drop down.
| *  d094d05 : Only show filter controls when mailbox layer is active.
| *  37a9992 : Add filter controls to front end.
|/  
*  6a53fa1 : add changelog
```
